### PR TITLE
Fixed typographical error, changed accross to across in README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Then:
     CFLAGS="-O2 -Wall -march=native" ./configure <options>
     make
 
-To compile a version that can be used accross machines, remove
+To compile a version that can be used across machines, remove
 `-march=native`.
 
 To compile a debug version, replace `-O2` with `-ggdb`.


### PR DESCRIPTION
@lasybear, I've corrected a typographical error in the documentation of the [sph-sgminer_x11mod](https://github.com/lasybear/sph-sgminer_x11mod) project. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.
